### PR TITLE
Add ability to unmerge empty value for columns.

### DIFF
--- a/GroupGridView.php
+++ b/GroupGridView.php
@@ -47,6 +47,16 @@ class GroupGridView extends GridView
      */
     public $type = self::MERGE_SIMPLE;
     /**
+     * Need to merge null values in columns? Default - merge on.
+     * @var boolean
+     */
+    public $doNotMergeEmptyValue = false;
+    /**
+     * Exclude column for the rule if [[GroupGridView::doNotMergeEmptyValue]] is true.
+     * @var array
+     */
+    public $mergeEmptyColumns = [];
+    /**
      * @var string the CSS class to use for the merged cells
      */
     public $mergeCellClass = 'groupview-merge-cells';
@@ -146,7 +156,9 @@ class GroupGridView extends GridView
             $changedColumns = [];
             foreach ($rowValues as $name => $value) {
                 $previous = end($groups[$name]);
-                if ($value != $previous['value']) {
+                if ($this->doNotMergeEmptyValue && empty($value) && !in_array($name, $this->mergeEmptyColumns, true)) {
+                    $changedColumns[] = $name;
+                } elseif ($value != $previous['value']) {
                     $changedColumns[] = $name;
                 }
             }


### PR DESCRIPTION
By default empty value in column is merged. In some cases this inconvenience.

![image](https://cloud.githubusercontent.com/assets/874234/19028469/0adf26ca-8945-11e6-9464-84f735d8520c.png)

To fix it:

``` php
<?= GroupGridView::widget(
            [
                'type' => GroupGridView::MERGE_NESTED,
                'doNotMergeEmptyValue' => true,          
                'mergeColumns' => ['mapFile', 'operatorID', 'operator', 'converter', 'portID'],
```

![image](https://cloud.githubusercontent.com/assets/874234/19028502/669eb34a-8945-11e6-8765-f91a2811a6b3.png)

You can exclude a column from this rule via `$mergeEmptyColumns`:

``` php
<?= GroupGridView::widget(
            [
                'type' => GroupGridView::MERGE_NESTED,
                'doNotMergeEmptyValue' => true,
                'mergeEmptyColumns' => ['mapFile'],
                'mergeColumns' => ['mapFile', 'operatorID', 'operator', 'converter', 'portID'],
```

![image](https://cloud.githubusercontent.com/assets/874234/19028547/e819d468-8945-11e6-927c-595aba781814.png)
